### PR TITLE
Migrate to abstract Record.

### DIFF
--- a/src/GdbMi/Interpreter.cs
+++ b/src/GdbMi/Interpreter.cs
@@ -8,7 +8,7 @@
 
     public static class Interpreter
     {
-        public static IRecord ParseOutputLine(string line)
+        public static Record ParseOutputLine(string line)
         {
             if (string.IsNullOrEmpty(line))
             {

--- a/src/GdbMi/Records/AsyncRecord.cs
+++ b/src/GdbMi/Records/AsyncRecord.cs
@@ -8,7 +8,7 @@
     // status-async-output contains on-going status information about the progress of a slow operation. It can be discarded. All status output is prefixed by ‘+’.
     // notify-async-output contains supplementary information that the client should handle(e.g., a new breakpoint information). All notify output is prefixed by ‘=’.
     // https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Output-Syntax.html#GDB_002fMI-Output-Syntax
-    public class AsyncRecord : TupleValue, IOutOfBandRecord
+    public class AsyncRecord : Record
     {
         public const char ExecPrefix = '*';
 

--- a/src/GdbMi/Records/IOutOfBandRecord.cs
+++ b/src/GdbMi/Records/IOutOfBandRecord.cs
@@ -1,6 +1,0 @@
-﻿namespace GdbMi.Records
-{
-    public interface IOutOfBandRecord : IRecord
-    {
-    }
-}

--- a/src/GdbMi/Records/IRecord.cs
+++ b/src/GdbMi/Records/IRecord.cs
@@ -1,6 +1,0 @@
-namespace GdbMi.Records
-{
-    public interface IRecord
-    {
-    }
-}

--- a/src/GdbMi/Records/PromptRecord.cs
+++ b/src/GdbMi/Records/PromptRecord.cs
@@ -1,6 +1,6 @@
 ﻿namespace GdbMi.Records
 {
-    public class PromptRecord : IRecord
+    public class PromptRecord : Record
     {
         public const string Prompt = "(gdb)";
 

--- a/src/GdbMi/Records/Record.cs
+++ b/src/GdbMi/Records/Record.cs
@@ -1,0 +1,19 @@
+namespace GdbMi.Records
+{
+    using System.Collections.Generic;
+    using GdbMi.Values;
+
+    public abstract class Record : TupleValue
+    {
+        protected Record()
+        {
+        }
+
+        protected Record(IEnumerable<Value> values)
+            : base(values)
+        {
+        }
+
+        public bool IsOutOfBand => this is AsyncRecord || this is StreamRecord;
+    }
+}

--- a/src/GdbMi/Records/ResultRecord.cs
+++ b/src/GdbMi/Records/ResultRecord.cs
@@ -4,7 +4,7 @@ namespace GdbMi.Records
     using System.Collections.Generic;
     using GdbMi.Values;
 
-    public class ResultRecord : TupleValue, IRecord
+    public class ResultRecord : Record
     {
         public const char ResultPrefix = '^';
 

--- a/src/GdbMi/Records/StreamRecord.cs
+++ b/src/GdbMi/Records/StreamRecord.cs
@@ -2,7 +2,7 @@ namespace GdbMi.Records
 {
     using System;
 
-    public class StreamRecord : IOutOfBandRecord
+    public class StreamRecord : Record
     {
         public const char ConsolePrefix = '~';
 

--- a/src/GdbMi/Values/TupleValue.cs
+++ b/src/GdbMi/Values/TupleValue.cs
@@ -13,6 +13,13 @@
 
         private readonly IReadOnlyList<string> order;
 
+        protected TupleValue()
+        {
+            values = new ReadOnlyDictionary<string, Value>(new Dictionary<string, Value>());
+
+            order = Array.Empty<string>().ToList();
+        }
+
         public TupleValue(IEnumerable<Value> values)
         {
             if (values is null)


### PR DESCRIPTION
- Prefer an `abstract` `Record` base class which is more consistent with `Value`.